### PR TITLE
Revamp league analyzer UI with summary and radar chart

### DIFF
--- a/GEM_LG-IG.html
+++ b/GEM_LG-IG.html
@@ -54,8 +54,11 @@
         
         .chart-container {
             position: relative;
-            height: 450px;
             width: 100%;
+            height: 300px;
+        }
+        @media (min-width: 768px) {
+            .chart-container { height: 450px; }
         }
 
         .rank-grid-item {
@@ -68,7 +71,7 @@
 
         .power-grid-row {
             border-bottom: 1px solid rgba(128, 138, 189, 0.1);
-            padding: 0.5rem 0.25rem;
+            padding: 0.25rem 0.25rem;
         }
         .power-grid-row:last-child {
             border-bottom: none;
@@ -81,17 +84,17 @@
     <div class="max-w-7xl mx-auto space-y-8">
         <!-- Header -->
         <header class="text-center space-y-4">
-            <h1 class="text-4xl md:text-5xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
+            <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
             <p class="text-lg text-gray-400">An infographic breakdown of your team's value using KTC metrics.</p>
         </header>
 
         <!-- Controls -->
         <div class="glass-panel p-4 flex flex-col md:flex-row items-center justify-center gap-4">
-            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 w-full md:w-auto">
-            <select id="leagueSelect" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 w-full md:w-auto" disabled>
+            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 focus:bg-gray-800 appearance-none w-full md:w-auto">
+            <select id="leagueSelect" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 w-full md:w-auto hidden" disabled>
                 <option>Select a league...</option>
             </select>
-            <button id="fetchDataButton" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors w-full md:w-auto">Analyze League</button>
+            <button id="fetchDataButton" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors w-full md:w-auto">Find Leagues</button>
         </div>
         
         <!-- Loading Indicator -->
@@ -101,6 +104,26 @@
 
         <!-- Main Content -->
         <main id="infographicContent" class="hidden space-y-12">
+            <!-- Summary Cards -->
+            <section id="summarySection" class="hidden grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div class="glass-panel p-4 text-center">
+                    <h3 class="text-sm text-gray-400">Team Rank</h3>
+                    <p id="summaryTeamRank" class="text-xl font-bold">-</p>
+                </div>
+                <div class="glass-panel p-4 text-center">
+                    <h3 class="text-sm text-gray-400">Total KTC</h3>
+                    <p id="summaryTotalKtc" class="text-xl font-bold">-</p>
+                </div>
+                <div class="glass-panel p-4 text-center">
+                    <h3 class="text-sm text-gray-400">Starters Rank</h3>
+                    <p id="summaryStartersRank" class="text-xl font-bold">-</p>
+                </div>
+                <div class="glass-panel p-4 text-center">
+                    <h3 class="text-sm text-gray-400">Top Player</h3>
+                    <p id="summaryTopPlayer" class="text-xl font-bold truncate">-</p>
+                </div>
+            </section>
+
             <!-- Top Level Charts -->
             <section class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                 <div class="glass-panel p-6">
@@ -117,10 +140,18 @@
                 </div>
             </section>
 
-            <!-- Detailed Starter Rankings -->
+            <!-- Top Options Radar -->
             <section class="glass-panel p-6">
-                <h2 class="text-2xl text-center mb-6">Starting Position Power Grid</h2>
-                <div id="starterRankingsGrid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                <h2 class="text-2xl text-center mb-4">Top Options vs League Average</h2>
+                <div class="chart-container">
+                    <canvas id="topOptionsRadar"></canvas>
+                </div>
+            </section>
+
+            <!-- Detailed Starter Rankings -->
+            <section class="glass-panel p-4">
+                <h2 class="text-xl text-center mb-4">Starting Position Power Grid</h2>
+                <div id="starterRankingsGrid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                     <!-- Grid items will be injected here by JavaScript -->
                 </div>
             </section>
@@ -150,9 +181,14 @@
         const loadingIndicator = document.getElementById('loading');
         const infographicContent = document.getElementById('infographicContent');
         const starterRankingsGrid = document.getElementById('starterRankingsGrid');
+        const summarySection = document.getElementById('summarySection');
+        const teamRankEl = document.getElementById('summaryTeamRank');
+        const totalKtcEl = document.getElementById('summaryTotalKtc');
+        const startersRankEl = document.getElementById('summaryStartersRank');
+        const topPlayerEl = document.getElementById('summaryTopPlayer');
 
         // --- Chart instances ---
-        let overallChart, startersChart;
+        let overallChart, startersChart, radarChart;
 
         // --- State ---
         let state = {
@@ -181,6 +217,11 @@
 
         // --- Event Listeners ---
         fetchDataButton.addEventListener('click', handleFetchData);
+        usernameInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleFetchData(); });
+        usernameInput.addEventListener('input', () => {
+            leagueSelect.classList.add('hidden');
+            fetchDataButton.textContent = 'Find Leagues';
+        });
 
         // --- Main Logic ---
         async function handleFetchData() {
@@ -192,27 +233,25 @@
 
             setLoading(true);
             infographicContent.classList.add('hidden');
+            summarySection.classList.add('hidden');
 
             try {
-                if (username.toLowerCase() !== state.username?.toLowerCase()) {
+                if (leagueSelect.classList.contains('hidden') || username.toLowerCase() !== state.username?.toLowerCase()) {
                     await fetchAndSetUser(username);
                     await fetchUserLeagues(state.userId);
                     populateLeagueSelect(state.leagues);
-                    if (state.leagues.length > 0) {
-                        leagueSelect.selectedIndex = 1;
-                    }
                     state.username = username;
+                    setLoading(false);
+                    return;
                 }
 
                 const leagueId = leagueSelect.value;
                 if (!leagueId || leagueId === 'Select a league...') {
-                    if (leagueSelect.selectedIndex > 0) {} else {
-                        alert('Please select a league to analyze.');
-                        setLoading(false);
-                        return;
-                    }
+                    alert('Please select a league to analyze.');
+                    setLoading(false);
+                    return;
                 }
-                
+
                 state.currentLeagueId = leagueId;
 
                 if (Object.keys(state.players).length === 0) await fetchSleeperPlayers();
@@ -231,7 +270,9 @@
         function setLoading(isLoading) {
             loadingIndicator.classList.toggle('hidden', !isLoading);
             fetchDataButton.disabled = isLoading;
-            fetchDataButton.textContent = isLoading ? 'Analyzing...' : 'Analyze League';
+            fetchDataButton.textContent = isLoading 
+                ? 'Loading...'
+                : (leagueSelect.classList.contains('hidden') ? 'Find Leagues' : 'Analyze League');
         }
 
         async function fetchAndSetUser(username) {
@@ -259,6 +300,8 @@
                 leagueSelect.appendChild(opt);
             });
             leagueSelect.disabled = false;
+            leagueSelect.classList.remove('hidden');
+            fetchDataButton.textContent = 'Analyze League';
         }
         
         async function fetchSleeperPlayers() {
@@ -320,9 +363,11 @@
             ]);
 
             const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
-            
+
             infographicContent.classList.remove('hidden');
+            renderSummary(teams);
             renderCharts(teams);
+            renderRadarChart(teams);
             renderStarterGrid(teams, leagueInfo);
         }
 
@@ -490,6 +535,77 @@
             });
         }
 
+        function renderSummary(teams) {
+            const userIndex = teams.findIndex(t => t.isUserTeam);
+            const userTeam = teams[userIndex];
+            if (!userTeam) return;
+
+            const startersTotals = teams.map(t => Object.values(t.startersPositional).reduce((a,b)=>a+b,0));
+            const startersRank = [...startersTotals].sort((a,b)=>b-a).indexOf(startersTotals[userIndex]) + 1;
+
+            const playerValues = (userTeam.roster.players || []).map(pId => ({
+                name: state.players[pId] ? `${state.players[pId].first_name} ${state.players[pId].last_name}` : '',
+                value: getKtcValue(pId)
+            })).sort((a,b)=>b.value-a.value);
+            const topPlayer = playerValues[0];
+
+            teamRankEl.textContent = `${userIndex + 1}/${teams.length}`;
+            totalKtcEl.textContent = userTeam.totalValue.toLocaleString();
+            startersRankEl.textContent = `${startersRank}/${teams.length}`;
+            topPlayerEl.textContent = topPlayer ? `${topPlayer.name} (${topPlayer.value.toLocaleString()})` : 'N/A';
+
+            summarySection.classList.remove('hidden');
+        }
+
+        function renderRadarChart(teams) {
+            const positions = ['QB','RB','WR','TE'];
+            const userTeam = teams.find(t => t.isUserTeam);
+            if (!userTeam) return;
+
+            const userValues = positions.map(pos => {
+                const players = (userTeam.roster.players || []).filter(pId => state.players[pId]?.position === pos);
+                const sorted = players.map(pId => getKtcValue(pId)).sort((a,b)=>b-a);
+                return (sorted[0]||0) + (sorted[1]||0);
+            });
+
+            const leagueAverages = positions.map(pos => {
+                const totals = teams.map(team => {
+                    const players = (team.roster.players || []).filter(pId => state.players[pId]?.position === pos);
+                    const sorted = players.map(pId => getKtcValue(pId)).sort((a,b)=>b-a);
+                    return (sorted[0]||0) + (sorted[1]||0);
+                });
+                return totals.reduce((a,b)=>a+b,0)/totals.length;
+            });
+
+            if (radarChart) radarChart.destroy();
+            radarChart = new Chart(document.getElementById('topOptionsRadar'), {
+                type: 'radar',
+                data: {
+                    labels: positions,
+                    datasets: [
+                        {
+                            label: userTeam.teamName,
+                            data: userValues,
+                            borderColor: '#FF3A75',
+                            backgroundColor: 'rgba(255,58,117,0.3)'
+                        },
+                        {
+                            label: 'League Avg',
+                            data: leagueAverages,
+                            borderColor: '#00EBC7',
+                            backgroundColor: 'rgba(0,235,199,0.3)'
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: { r: { grid: { color: 'rgba(255,255,255,0.1)' }, angleLines: { color: 'rgba(255,255,255,0.1)' }, ticks: { display: false } } },
+                    plugins: { legend: { position: 'bottom', labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } } } }
+                }
+            });
+        }
+
         function renderStarterGrid(teams, leagueInfo) {
             starterRankingsGrid.innerHTML = '';
             const rosterPositions = leagueInfo.roster_positions;
@@ -537,21 +653,21 @@
                 slotData.sort((a, b) => b.ktcValue - a.ktcValue);
 
                 const gridItem = document.createElement('div');
-                gridItem.className = 'glass-panel p-4 rank-grid-item';
+                gridItem.className = 'glass-panel p-3 rank-grid-item text-xs';
 
-                let content = `<h3 class="text-xl font-bold text-center mb-3">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
+                let content = `<h3 class="text-lg font-bold text-center mb-2">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
                 slotData.forEach((data, index) => {
                     const rank = index + 1;
                     const color = getRankColor(rank, teams.length);
                     content += `
-                        <li class="flex justify-between items-center text-sm power-grid-row">
+                        <li class="flex justify-between items-center text-xs power-grid-row">
                             <div class="flex items-center w-2/3">
                                 <span class="font-bold w-6 flex-shrink-0" style="color: ${color};">${rank}.</span>
                                 <span class="truncate">${data.teamName}</span>
                             </div>
                             <div class="text-right w-1/3">
                                 <span class="font-semibold" style="color: ${color};">${data.ktcValue.toLocaleString()}</span>
-                                <p class="text-xs text-gray-400 truncate">${data.playerName}</p>
+                                <p class="text-[10px] text-gray-400 truncate">${data.playerName}</p>
                             </div>
                         </li>
                     `;


### PR DESCRIPTION
## Summary
- Shrink main title and streamline controls while hiding league selection until username lookup.
- Add summary cards, mobile-friendly radar chart, and responsive chart sizing.
- Compress starting position power grid with smaller typography and padding.

## Testing
- `npx -y htmlhint GEM_LG-IG.html`


------
https://chatgpt.com/codex/tasks/task_e_68b220373f4c832eb04ddcd2a765ffbf