### PR TITLE
Revamp infographic page with mobile layout, summary stats, and radar chart

### DIFF
--- a/GEM_LG-IG.html
+++ b/GEM_LG-IG.html
@@ -54,8 +54,13 @@
         
         .chart-container {
             position: relative;
-            height: 450px;
+            height: 300px;
             width: 100%;
+        }
+        @media (min-width: 768px) {
+            .chart-container {
+                height: 450px;
+            }
         }
 
         .rank-grid-item {
@@ -68,7 +73,7 @@
 
         .power-grid-row {
             border-bottom: 1px solid rgba(128, 138, 189, 0.1);
-            padding: 0.5rem 0.25rem;
+            padding: 0.25rem 0.25rem;
         }
         .power-grid-row:last-child {
             border-bottom: none;
@@ -81,17 +86,22 @@
     <div class="max-w-7xl mx-auto space-y-8">
         <!-- Header -->
         <header class="text-center space-y-4">
-            <h1 class="text-4xl md:text-5xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
+            <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
             <p class="text-lg text-gray-400">An infographic breakdown of your team's value using KTC metrics.</p>
         </header>
 
         <!-- Controls -->
         <div class="glass-panel p-4 flex flex-col md:flex-row items-center justify-center gap-4">
-            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 w-full md:w-auto">
-            <select id="leagueSelect" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 w-full md:w-auto" disabled>
-                <option>Select a league...</option>
-            </select>
-            <button id="fetchDataButton" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors w-full md:w-auto">Analyze League</button>
+            <div id="userControls" class="flex flex-col md:flex-row gap-4 w-full md:w-auto">
+                <input type="text" id="usernameInput" placeholder="Enter Sleeper Username" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-purple-500 focus:ring-0 w-full md:w-auto">
+                <button id="loadLeaguesButton" data-default="Load Leagues" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors w-full md:w-auto">Load Leagues</button>
+            </div>
+            <div id="leagueControls" class="hidden flex flex-col md:flex-row gap-4 w-full md:w-auto">
+                <select id="leagueSelect" class="bg-gray-900/50 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-purple-500 focus:ring-0 w-full md:w-auto">
+                    <option value="">Select a league...</option>
+                </select>
+                <button id="analyzeLeagueButton" data-default="Analyze League" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition-colors w-full md:w-auto">Analyze League</button>
+            </div>
         </div>
         
         <!-- Loading Indicator -->
@@ -101,6 +111,9 @@
 
         <!-- Main Content -->
         <main id="infographicContent" class="hidden space-y-12">
+            <!-- Summary -->
+            <section id="summarySection" class="grid grid-cols-2 md:grid-cols-4 gap-4"></section>
+
             <!-- Top Level Charts -->
             <section class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                 <div class="glass-panel p-6">
@@ -117,10 +130,18 @@
                 </div>
             </section>
 
+            <!-- Positional Radar -->
+            <section class="glass-panel p-6">
+                <h2 class="text-2xl text-center mb-4">Top Positional Options vs League</h2>
+                <div class="chart-container">
+                    <canvas id="positionalRadarChart"></canvas>
+                </div>
+            </section>
+
             <!-- Detailed Starter Rankings -->
             <section class="glass-panel p-6">
-                <h2 class="text-2xl text-center mb-6">Starting Position Power Grid</h2>
-                <div id="starterRankingsGrid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                <h2 class="text-xl text-center mb-4">Starting Position Power Grid</h2>
+                <div id="starterRankingsGrid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                     <!-- Grid items will be injected here by JavaScript -->
                 </div>
             </section>
@@ -146,13 +167,16 @@
         // --- DOM Elements ---
         const usernameInput = document.getElementById('usernameInput');
         const leagueSelect = document.getElementById('leagueSelect');
-        const fetchDataButton = document.getElementById('fetchDataButton');
+        const loadLeaguesButton = document.getElementById('loadLeaguesButton');
+        const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
+        const leagueControls = document.getElementById('leagueControls');
         const loadingIndicator = document.getElementById('loading');
         const infographicContent = document.getElementById('infographicContent');
         const starterRankingsGrid = document.getElementById('starterRankingsGrid');
+        const summarySection = document.getElementById('summarySection');
 
         // --- Chart instances ---
-        let overallChart, startersChart;
+        let overallChart, startersChart, radarChart;
 
         // --- State ---
         let state = {
@@ -180,58 +204,63 @@
 
 
         // --- Event Listeners ---
-        fetchDataButton.addEventListener('click', handleFetchData);
+        loadLeaguesButton.addEventListener('click', handleLoadLeagues);
+        analyzeLeagueButton.addEventListener('click', handleAnalyzeLeague);
 
         // --- Main Logic ---
-        async function handleFetchData() {
+        async function handleLoadLeagues() {
             const username = usernameInput.value.trim();
             if (!username) {
                 alert('Please enter a Sleeper username.');
                 return;
             }
-
-            setLoading(true);
-            infographicContent.classList.add('hidden');
-
+            setLoading(true, loadLeaguesButton);
             try {
-                if (username.toLowerCase() !== state.username?.toLowerCase()) {
-                    await fetchAndSetUser(username);
-                    await fetchUserLeagues(state.userId);
-                    populateLeagueSelect(state.leagues);
-                    if (state.leagues.length > 0) {
-                        leagueSelect.selectedIndex = 1;
-                    }
-                    state.username = username;
+                await fetchAndSetUser(username);
+                await fetchUserLeagues(state.userId);
+                populateLeagueSelect(state.leagues);
+                if (state.leagues.length > 0) {
+                    leagueControls.classList.remove('hidden');
                 }
+                state.username = username;
+            } catch (error) {
+                console.error('Error loading leagues:', error);
+                alert(`An error occurred: ${error.message}`);
+            } finally {
+                setLoading(false, loadLeaguesButton);
+            }
+        }
 
-                const leagueId = leagueSelect.value;
-                if (!leagueId || leagueId === 'Select a league...') {
-                    if (leagueSelect.selectedIndex > 0) {} else {
-                        alert('Please select a league to analyze.');
-                        setLoading(false);
-                        return;
-                    }
-                }
-                
+        async function handleAnalyzeLeague() {
+            const leagueId = leagueSelect.value;
+            if (!leagueId) {
+                alert('Please select a league to analyze.');
+                return;
+            }
+
+            infographicContent.classList.add('hidden');
+            setLoading(true, analyzeLeagueButton);
+            try {
                 state.currentLeagueId = leagueId;
-
                 if (Object.keys(state.players).length === 0) await fetchSleeperPlayers();
                 if (Object.keys(state.oneQbData).length === 0) await fetchDataFromGoogleSheet();
-
                 await analyzeLeague();
-
             } catch (error) {
                 console.error('Error fetching data:', error);
                 alert(`An error occurred: ${error.message}`);
             } finally {
-                setLoading(false);
+                setLoading(false, analyzeLeagueButton);
             }
         }
 
-        function setLoading(isLoading) {
+        function setLoading(isLoading, button) {
             loadingIndicator.classList.toggle('hidden', !isLoading);
-            fetchDataButton.disabled = isLoading;
-            fetchDataButton.textContent = isLoading ? 'Analyzing...' : 'Analyze League';
+            if (button) {
+                button.disabled = isLoading;
+                button.textContent = isLoading
+                    ? (button.id === 'analyzeLeagueButton' ? 'Analyzing...' : 'Loading...')
+                    : button.dataset.default;
+            }
         }
 
         async function fetchAndSetUser(username) {
@@ -320,8 +349,9 @@
             ]);
 
             const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
-            
+
             infographicContent.classList.remove('hidden');
+            renderSummary(teams);
             renderCharts(teams);
             renderStarterGrid(teams, leagueInfo);
         }
@@ -332,13 +362,18 @@
             return rosters.map(roster => {
                 const owner = userMap[roster.owner_id];
                 const teamName = owner?.display_name || `Team ${roster.roster_id}`;
-                
+
                 const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
+                const positionalPlayers = { QB: [], RB: [], WR: [], TE: [] };
+                let topPlayerValue = 0, topPlayerId = null;
                 (roster.players || []).forEach(pId => {
                     const playerInfo = state.players[pId];
+                    const val = getKtcValue(pId);
                     if (playerInfo && overallPositional.hasOwnProperty(playerInfo.position)) {
-                        overallPositional[playerInfo.position] += getKtcValue(pId);
+                        overallPositional[playerInfo.position] += val;
+                        if (positionalPlayers[playerInfo.position]) positionalPlayers[playerInfo.position].push(val);
                     }
+                    if (val > topPlayerValue) { topPlayerValue = val; topPlayerId = pId; }
                 });
                 getOwnedPicks(roster.roster_id, tradedPicks, leagueInfo).forEach(p => {
                     overallPositional.Picks += getKtcValue(p.label);
@@ -350,20 +385,29 @@
 
                 starterIds.forEach((pId, index) => {
                     const slot = rosterPositions[index];
-                    // Check if the slot is one of the types we are tracking for the chart.
                     if (startersPositional.hasOwnProperty(slot)) {
                         startersPositional[slot] += getKtcValue(pId);
                     }
                 });
-                
+
+                const startersTotal = Object.values(startersPositional).reduce((a, b) => a + b, 0);
                 const totalValue = Object.values(overallPositional).reduce((a, b) => a + b, 0);
+
+                const topInfo = state.players[topPlayerId] || {};
+                const topPlayer = {
+                    name: topInfo.first_name ? `${topInfo.first_name} ${topInfo.last_name}` : 'N/A',
+                    value: topPlayerValue
+                };
 
                 return {
                     teamName,
                     totalValue,
+                    startersTotal,
                     overallPositional,
                     startersPositional,
+                    positionalPlayers,
                     roster,
+                    topPlayer,
                     isUserTeam: roster.owner_id === state.userId
                 };
             }).sort((a,b) => b.totalValue - a.totalValue);
@@ -398,7 +442,31 @@
                 .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
                 .map(p => ({ ...p, label: `${p.season} Mid ${ordinal(p.round)}` }));
         }
-        
+
+        function renderSummary(teams) {
+            summarySection.innerHTML = '';
+            const userIndex = teams.findIndex(t => t.isUserTeam);
+            if (userIndex === -1) return;
+            const userTeam = teams[userIndex];
+            const startersRank = [...teams]
+                .sort((a, b) => b.startersTotal - a.startersTotal)
+                .findIndex(t => t.teamName === userTeam.teamName) + 1;
+
+            const boxes = [
+                { label: 'Team Rank', value: `${userIndex + 1} / ${teams.length}` },
+                { label: 'Total KTC Value', value: userTeam.totalValue.toLocaleString() },
+                { label: 'Starters Rank', value: `${startersRank} / ${teams.length}` },
+                { label: 'Top Player', value: `${userTeam.topPlayer.name} (${userTeam.topPlayer.value.toLocaleString()})` }
+            ];
+
+            boxes.forEach(b => {
+                const div = document.createElement('div');
+                div.className = 'glass-panel p-4 text-center';
+                div.innerHTML = `<h3 class="text-sm text-gray-400">${b.label}</h3><p class="text-xl font-bold mt-1">${b.value}</p>`;
+                summarySection.appendChild(div);
+            });
+        }
+
         function renderCharts(teams) {
             const labels = teams.map(t => t.teamName);
             
@@ -488,6 +556,48 @@
                 },
                 options: chartOptions()
             });
+
+            // Radar Chart
+            const userTeam = teams.find(t => t.isUserTeam);
+            const positions = ['QB', 'RB', 'WR', 'TE'];
+            const userTop = positions.map(pos => {
+                const vals = userTeam.positionalPlayers[pos] || [];
+                vals.sort((a, b) => b - a);
+                return vals.slice(0, 2).reduce((a, b) => a + b, 0);
+            });
+            const leagueAvg = positions.map(pos => {
+                const sums = teams.map(team => {
+                    const vals = team.positionalPlayers[pos] || [];
+                    vals.sort((a, b) => b - a);
+                    return vals.slice(0, 2).reduce((a, b) => a + b, 0);
+                });
+                return sums.reduce((a, b) => a + b, 0) / sums.length;
+            });
+            if (radarChart) radarChart.destroy();
+            radarChart = new Chart(document.getElementById('positionalRadarChart'), {
+                type: 'radar',
+                data: {
+                    labels: positions,
+                    datasets: [
+                        { label: userTeam.teamName, data: userTop, backgroundColor: 'rgba(118,109,255,0.4)', borderColor: '#766dff' },
+                        { label: 'League Average', data: leagueAvg, backgroundColor: 'rgba(0,235,199,0.2)', borderColor: '#00EBC7' }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    plugins: {
+                        legend: { labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } } }
+                    },
+                    scales: {
+                        r: {
+                            angleLines: { color: 'rgba(255,255,255,0.1)' },
+                            grid: { color: 'rgba(255,255,255,0.1)' },
+                            pointLabels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } },
+                            ticks: { backdropColor: 'transparent', color: '#EAEBF0' }
+                        }
+                    }
+                }
+            });
         }
 
         function renderStarterGrid(teams, leagueInfo) {
@@ -537,21 +647,21 @@
                 slotData.sort((a, b) => b.ktcValue - a.ktcValue);
 
                 const gridItem = document.createElement('div');
-                gridItem.className = 'glass-panel p-4 rank-grid-item';
+                gridItem.className = 'glass-panel p-3 rank-grid-item text-xs';
 
-                let content = `<h3 class="text-xl font-bold text-center mb-3">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
+                let content = `<h3 class="text-lg font-bold text-center mb-2">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
                 slotData.forEach((data, index) => {
                     const rank = index + 1;
                     const color = getRankColor(rank, teams.length);
                     content += `
-                        <li class="flex justify-between items-center text-sm power-grid-row">
+                        <li class="flex justify-between items-center text-xs power-grid-row">
                             <div class="flex items-center w-2/3">
-                                <span class="font-bold w-6 flex-shrink-0" style="color: ${color};">${rank}.</span>
+                                <span class="font-bold w-5 flex-shrink-0" style="color: ${color};">${rank}.</span>
                                 <span class="truncate">${data.teamName}</span>
                             </div>
                             <div class="text-right w-1/3">
                                 <span class="font-semibold" style="color: ${color};">${data.ktcValue.toLocaleString()}</span>
-                                <p class="text-xs text-gray-400 truncate">${data.playerName}</p>
+                                <p class="text-[10px] text-gray-400 truncate">${data.playerName}</p>
                             </div>
                         </li>
                     `;


### PR DESCRIPTION
## Summary
- Shrunk headline and rebuilt controls to hide league selection until a username is submitted, improving focus and mobile usability.
- Added summary cards and a radar chart comparing top positional options against league averages, giving at-a-glance insights.
- Streamlined power grid display and responsive chart sizing for a compact, mobile-friendly infographic.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b220373f4c832eb04ddcd2a765ffbf